### PR TITLE
🚒 fix listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ bin/
 
 .DS_Store
 test/*.yaml
+*.coverprofile

--- a/pkg/executor/interface.go
+++ b/pkg/executor/interface.go
@@ -10,6 +10,7 @@ type QingCloudListenerExecutor interface {
 	DeleteListener(lsnid string) error
 	CreateListener(*qcservice.AddLoadBalancerListenersInput) (*qcservice.LoadBalancerListener, error)
 	ModifyListener(id, balanceMode string) error
+	GetListenerByName(lbid, name string) (*qcservice.LoadBalancerListener, error)
 }
 
 type QingCloudListenerBackendExecutor interface {

--- a/pkg/executor/lb_executor.go
+++ b/pkg/executor/lb_executor.go
@@ -272,6 +272,21 @@ func (q *qingCloudLoadBalanceExecutor) GetListenerByID(id string) (*qcservice.Lo
 	return output.LoadBalancerListenerSet[0], nil
 }
 
+func (q *qingCloudLoadBalanceExecutor) GetListenerByName(id, name string) (*qcservice.LoadBalancerListener, error) {
+	output, err := q.lbapi.DescribeLoadBalancerListeners(&qcservice.DescribeLoadBalancerListenersInput{
+		LoadBalancer: &id,
+	})
+	if err != nil {
+		return nil, err
+	}
+	for _, list := range output.LoadBalancerListenerSet {
+		if *list.LoadBalancerListenerName == name {
+			return list, nil
+		}
+	}
+	return nil, nil
+}
+
 func (q *qingCloudLoadBalanceExecutor) ModifyListener(id, balanceMode string) error {
 	output, err := q.lbapi.ModifyLoadBalancerListenerAttributes(&qcservice.ModifyLoadBalancerListenerAttributesInput{
 		LoadBalancerListener: &id,

--- a/pkg/loadbalance/loadbalancer_listener.go
+++ b/pkg/loadbalance/loadbalancer_listener.go
@@ -69,18 +69,15 @@ func NewListener(lb *LoadBalancer, port int) (*Listener, error) {
 
 // LoadQcListener get real lb in qingcloud
 func (l *Listener) LoadQcListener() error {
-	listeners, err := l.listenerExec.GetListenersOfLB(*l.lb.Status.QcLoadBalancer.LoadBalancerID, l.Name)
+	listener, err := l.listenerExec.GetListenerByName(*l.lb.Status.QcLoadBalancer.LoadBalancerID, l.Name)
 	if err != nil {
 		klog.Errorf("Failed to get listener of this service %s with port %d", l.Name, l.ListenerPort)
 		return err
 	}
-	if len(listeners) > 1 {
-		klog.Exit("Fatal ! Get multi listeners for one port, quit now")
-	}
-	if len(listeners) == 0 {
+	if listener == nil {
 		return ErrorListenerNotFound
 	}
-	l.Status = listeners[0]
+	l.Status = listener
 	return nil
 }
 

--- a/test/pkg/fake/lb.go
+++ b/test/pkg/fake/lb.go
@@ -135,6 +135,15 @@ func (f *FakeQingCloudLBExecutor) GetListenerByID(id string) (*qcservice.LoadBal
 	return f.Listeners[id], nil
 }
 
+func (f *FakeQingCloudLBExecutor) GetListenerByName(id, name string) (*qcservice.LoadBalancerListener, error) {
+	for _, v := range f.Listeners {
+		if *v.LoadBalancerListenerName == name && *v.LoadBalancerID == id {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
 func (f *FakeQingCloudLBExecutor) DeleteListener(lsnid string) error {
 	delete(f.Listeners, lsnid)
 	ids := []string{}


### PR DESCRIPTION
fix following bug:
when user change service ports like 80xx->80,（long port to short port with same prefix）, our plugin cannot recognize the change