### PR TITLE
loadbalance: set nodecount to 2 when create lb

### DIFF
--- a/pkg/loadbalance/loadbalancer.go
+++ b/pkg/loadbalance/loadbalancer.go
@@ -35,6 +35,7 @@ type LoadBalancerSpec struct {
 	Nodes       []*corev1.Node
 	Name        string
 	clusterName string
+	NodeCount   int
 	AnnotaionConfig
 }
 
@@ -56,6 +57,7 @@ type NewLoadBalancerOption struct {
 	ClusterName  string
 	SkipCheck    bool
 	DefaultVxnet string
+	NodeCount    int
 }
 
 // NewLoadBalancer create loadbalancer in memory, not in cloud, call 'CreateQingCloudLB' to create a real loadbalancer in qingcloud
@@ -73,6 +75,7 @@ func NewLoadBalancer(opt *NewLoadBalancerOption) (*LoadBalancer, error) {
 	result.service = opt.K8sService
 	result.Nodes = opt.K8sNodes
 	result.clusterName = opt.ClusterName
+	result.NodeCount = opt.NodeCount
 
 	config, err := ParseAnnotation(opt.K8sService.GetAnnotations(), false)
 	if err != nil {
@@ -245,6 +248,7 @@ func (l *LoadBalancer) CreateQingCloudLB() error {
 		LoadBalancerType: &l.ScaleType,
 		LoadBalancerName: &l.Name,
 		SecurityGroup:    l.Status.QcSecurityGroup.SecurityGroupID,
+		NodeCount:        &l.NodeCount,
 	}
 
 	if l.NetworkType == NetworkModePublic {

--- a/pkg/qingcloud/loadbalancer_impl.go
+++ b/pkg/qingcloud/loadbalancer_impl.go
@@ -13,6 +13,11 @@ import (
 	"k8s.io/klog"
 )
 
+const (
+	//The default node should be at least two, allowing for a minimum level of high availability.
+	defaultNodeCount = 2
+)
+
 var _ cloudprovider.LoadBalancer = &QingCloud{}
 
 func (qc *QingCloud) newLoadBalance(ctx context.Context, service *v1.Service, nodes []*v1.Node, skipCheck bool) (*loadbalance.LoadBalancer, error) {
@@ -38,6 +43,7 @@ func (qc *QingCloud) newLoadBalance(ctx context.Context, service *v1.Service, no
 		ClusterName:  qc.clusterID,
 		SkipCheck:    skipCheck,
 		DefaultVxnet: qc.defaultVxNetForLB,
+		NodeCount:    defaultNodeCount,
 	}
 	return loadbalance.NewLoadBalancer(opt)
 }

--- a/pkg/qingcloud/patch.go
+++ b/pkg/qingcloud/patch.go
@@ -1,14 +1,15 @@
 package qingcloud
 
 import (
+	"encoding/json"
 	"fmt"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/klog"
 )
-import corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-import "k8s.io/api/core/v1"
-import "k8s.io/apimachinery/pkg/types"
-import "encoding/json"
-import "k8s.io/apimachinery/pkg/util/strategicpatch"
 
 type servicePatcher struct {
 	kclient corev1.CoreV1Interface


### PR DESCRIPTION
Notice: We don't change the number of nodes of an existing load balancer, you can change it in the portal if you want.

and fixed some formatting issues

Signed-off-by: Duan Jiong <djduanjiong@gmail.com>