### PR TITLE
support auto delete lb/listener without annotation;

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # GitHub viewer defaults to 8, change with ?ts=4 in URL
 
 GIT_REPOSITORY= github.com/yunify/qingcloud-cloud-controller-manager
-IMG?= qingcloud/cloud-controller-manager:latest
+IMG?= qingcloud/cloud-controller-manager:v1.4.17
 #Debug level: 0, 1, 2 (1 true, 2 use bash)
 DEBUG?= 0
 DOCKERFILE?= deploy/Dockerfile

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,6 +41,7 @@ import (
 	// e.g. _"k8s.io/legacy-cloud-providers/<provider>"
 	"github.com/yunify/qingcloud-cloud-controller-manager/pkg/controllers/clusternode"
 	"github.com/yunify/qingcloud-cloud-controller-manager/pkg/controllers/endpoint"
+	"github.com/yunify/qingcloud-cloud-controller-manager/pkg/controllers/service"
 	_ "github.com/yunify/qingcloud-cloud-controller-manager/pkg/qingcloud"
 )
 
@@ -95,5 +96,6 @@ func controllerInitializers() map[string]app.InitFuncConstructor {
 	controllerInitializers := app.DefaultInitFuncConstructors
 	controllerInitializers["endpoint"] = endpoint.StartEndpointControllerWrapper
 	controllerInitializers["clusternode"] = clusternode.StartClusterNodeControllerWrapper
+	controllerInitializers["cloud-service"] = service.StartServiceControllerWarpper
 	return controllerInitializers
 }

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
         # Change the value of image field below to your controller image URL
-        - image: qingcloud/cloud-controller-manager:v1.4.10
+        - image: qingcloud/cloud-controller-manager:v1.4.17
           name: qingcloud-cloud-controller-manager
           imagePullPolicy: IfNotPresent

--- a/pkg/controllers/endpoint/endpoint_controller.go
+++ b/pkg/controllers/endpoint/endpoint_controller.go
@@ -175,7 +175,7 @@ func (epc *EndpointController) handleEndpointsUpdate(key string) error {
 	svc, err := epc.serviceLister.Services(namespace).Get(name)
 	if err != nil {
 		if k8sErr.IsNotFound(err) {
-			klog.V(4).Infof("endpoints %s/%s has no service, ignore!", namespace, name)
+			klog.V(4).Infof("endpoints %s/%s has no service, ignore handle endpoints update!", namespace, name)
 			return nil
 		}
 		return fmt.Errorf("get service %s/%s error: %v", namespace, name, err)

--- a/pkg/controllers/service/cloud_service_controller.go
+++ b/pkg/controllers/service/cloud_service_controller.go
@@ -1,0 +1,207 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	cloudprovider "k8s.io/cloud-provider"
+	cloudproviderapp "k8s.io/cloud-provider/app"
+	cloudcontrollerconfig "k8s.io/cloud-provider/app/config"
+	genericcontrollermanager "k8s.io/controller-manager/app"
+	"k8s.io/klog"
+
+	"github.com/yunify/qingcloud-cloud-controller-manager/pkg/qingcloud"
+)
+
+const (
+	serviceRunWorkerPeriod = 1 * time.Second
+	serviceWorkers         = 1
+)
+
+type ServiceController struct {
+	cloud cloudprovider.Interface
+
+	serviceLister       corelisters.ServiceLister
+	serviceListerSynced cache.InformerSynced
+	serviceQueue        workqueue.RateLimitingInterface
+}
+
+func StartServiceControllerWarpper(completedConfig *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface) cloudproviderapp.InitFunc {
+	return func(ctx genericcontrollermanager.ControllerContext) (http.Handler, bool, error) {
+		return startServiceController(completedConfig, cloud, ctx.Stop)
+	}
+}
+
+func startServiceController(ctx *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface, stopCh <-chan struct{}) (http.Handler, bool, error) {
+	// Start the endpoint controller
+	serviceController, err := New(
+		cloud,
+		ctx.ClientBuilder.ClientOrDie("cloud-service-controller"),
+		ctx.SharedInformers.Core().V1().Services(),
+	)
+	if err != nil {
+		// This error shouldn't fail. It lives like this as a legacy.
+		klog.Errorf("Failed to start cloud-service controller: %v", err)
+		return nil, false, nil
+	}
+
+	go serviceController.Run(stopCh, serviceWorkers)
+
+	return nil, true, nil
+}
+
+func New(
+	cloud cloudprovider.Interface,
+	kubeClient clientset.Interface,
+	serviceInformer coreinformers.ServiceInformer,
+) (*ServiceController, error) {
+
+	sc := &ServiceController{
+		cloud:               cloud,
+		serviceQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cloud-service"),
+		serviceLister:       serviceInformer.Lister(),
+		serviceListerSynced: serviceInformer.Informer().HasSynced,
+	}
+
+	serviceInformer.Informer().AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(old, cur interface{}) {
+				oldSvc, ok1 := old.(*corev1.Service)
+				newSvc, ok2 := cur.(*corev1.Service)
+				if ok1 && ok2 && sc.needClean(oldSvc, newSvc) {
+					sc.enqueueService(old)
+					// sc.cleanLBAndListener(oldSvc, newSvc)
+
+				}
+			},
+		},
+	)
+
+	return sc, nil
+}
+
+// for service which reuse lb, need to clean listener in those situations
+// change lb: lb1 -> lb2, need to clean lb1's listener ==> TODO
+// change service type: loadbalancer -> nodeport/clusterip, if service changed type and delete annotation, need clean lb(auto created lb) or listener(reuse-lb)
+func (sc *ServiceController) needClean(old, new *corev1.Service) bool {
+	if old.Spec.Type == corev1.ServiceTypeLoadBalancer {
+		if len(old.Annotations) == 0 {
+			klog.V(4).Infof("service %s/%s last config has no annotation, cloud-service-controller do nothing!", old.Namespace, old.Name)
+			return false
+		}
+		if new.Annotations == nil {
+			new.Annotations = make(map[string]string)
+		}
+
+		if new.Spec.Type == corev1.ServiceTypeLoadBalancer {
+			//TODO: change lb, clean listener for old listener  if change lb
+			klog.V(4).Infof("service %s/%s type not change, cloud-service-controller do nothing!", old.Namespace, old.Name)
+			return false
+		}
+
+		// change service type
+		// reuse-lb, clean listener if new service delete annotation
+		oldStrategy := old.Annotations[qingcloud.ServiceAnnotationLoadBalancerPolicy]
+		oldLBID := old.Annotations[qingcloud.ServiceAnnotationLoadBalancerID]
+		newStrategy := new.Annotations[qingcloud.ServiceAnnotationLoadBalancerPolicy]
+		newLBID := new.Annotations[qingcloud.ServiceAnnotationLoadBalancerID]
+		if oldStrategy == qingcloud.ReuseExistingLB && oldLBID != "" {
+			if newStrategy == oldStrategy && newLBID == oldLBID {
+				// new service keep reuse lb annotation, ignore!
+				klog.V(4).Infof("service %s/%s keep reuse lb id annotation, cloud-service-controller do nothing!", old.Namespace, old.Name)
+				return false
+			}
+			klog.V(4).Infof("service %s/%s deleted reuse lb id annotation, cloud-service-controller will try to delete lb later!", old.Namespace, old.Name)
+			return true
+		}
+
+	}
+	return false
+}
+
+func (sc *ServiceController) enqueueService(obj interface{}) {
+	_, ok := obj.(*corev1.Service)
+	if !ok {
+		return
+	}
+	sc.serviceQueue.Add(obj)
+}
+
+func (sc *ServiceController) Run(stopCh <-chan struct{}, workers int) {
+	defer runtime.HandleCrash()
+	defer sc.serviceQueue.ShutDown()
+
+	klog.Info("Starting cloud service controller")
+	defer klog.Info("Shutting down cloud service controller")
+
+	if !cache.WaitForCacheSync(stopCh, sc.serviceListerSynced) {
+		return
+	}
+
+	for i := 0; i < workers; i++ {
+		go wait.Until(sc.worker, serviceRunWorkerPeriod, stopCh)
+	}
+
+	<-stopCh
+}
+
+func (sc *ServiceController) worker() {
+	for sc.processNextWorkItem() {
+	}
+}
+
+func (sc *ServiceController) processNextWorkItem() bool {
+	obj, quit := sc.serviceQueue.Get()
+	if quit {
+		return false
+	}
+	defer sc.serviceQueue.Done(obj)
+
+	svc, ok := obj.(*corev1.Service)
+	if !ok {
+		runtime.HandleError(fmt.Errorf("error assert service %v (will retry)", svc))
+		return true
+	}
+	err := sc.handleServiceUpdate(svc)
+	if err == nil {
+		sc.serviceQueue.Forget(obj)
+		return true
+	}
+
+	runtime.HandleError(fmt.Errorf("error processing service %s/%s (will retry): %v", svc.Namespace, svc.Name, err))
+	sc.serviceQueue.AddRateLimited(obj)
+
+	return true
+}
+
+func (sc *ServiceController) handleServiceUpdate(svc *corev1.Service) error {
+	startTime := time.Now()
+	defer func() {
+		klog.V(4).Infof("Finished handleEndpointsUpdate  %s/%s (%v)", svc.Namespace, svc.Name, time.Since(startTime))
+	}()
+
+	cloudLbIntf, _ := sc.cloud.LoadBalancer()
+
+	listenerName := fmt.Sprintf("listener_%s_%s_", svc.Namespace, svc.Name)
+	lbID := svc.Annotations[qingcloud.ServiceAnnotationLoadBalancerID]
+
+	klog.Infof("service %s/%s type changed, and loadbalancer annotation has been deleted, try to deleting listener %s of loadbalancer %s",
+		svc.Namespace, svc.Name, listenerName, lbID)
+	err := cloudLbIntf.EnsureLoadBalancerDeleted(context.TODO(), "", svc)
+	if err != nil {
+		return fmt.Errorf("delete listener %s of loadbalancer %s for service %s/%s error: %v", listenerName, lbID, svc.Namespace, svc.Name, err)
+	}
+
+	klog.Infof("delete listener %s of loadbalancer %s for service %s/%s successful", listenerName, lbID, svc.Namespace, svc.Name)
+	return nil
+}

--- a/pkg/executor/lb.go
+++ b/pkg/executor/lb.go
@@ -271,7 +271,7 @@ func (q *QingCloudClient) DeleteLB(id *string) error {
 
 		err = qcclient.WaitJob(q.jobService, *output.JobID, operationWaitTimeout, waitInterval)
 		if err != nil {
-			return fmt.Errorf("lb %s delete job not completed", *id)
+			return fmt.Errorf("lb %s delete job not completed, err: %v", *id, err)
 		}
 	}
 

--- a/pkg/qingcloud/annotations.go
+++ b/pkg/qingcloud/annotations.go
@@ -140,15 +140,16 @@ func (qc *QingCloud) ParseServiceLBConfig(cluster string, service *v1.Service) (
 	lbEipIds, hasEip := annotation[ServiceAnnotationLoadBalancerEipIds]
 	if hasEip && lbEipIds != "" {
 		config.EipIDs = qcservice.StringSlice(strings.Split(lbEipIds, ","))
-	}
-	source := annotation[ServiceAnnotationLoadBalancerEipSource]
-	config.EipSource = &source
-	switch source {
-	case AllocateOnly:
-	case UseAvailableOnly:
-	case UseAvailableOrAllocateOne:
-	default:
-		config.EipSource = nil
+	} else {
+		source := annotation[ServiceAnnotationLoadBalancerEipSource]
+		config.EipSource = &source
+		switch source {
+		case AllocateOnly:
+		case UseAvailableOnly:
+		case UseAvailableOrAllocateOne:
+		default:
+			config.EipSource = nil
+		}
 	}
 
 	if vxnetID, ok := annotation[ServiceAnnotationLoadBalancerVxnetID]; ok {
@@ -193,14 +194,14 @@ func (qc *QingCloud) ParseServiceLBConfig(cluster string, service *v1.Service) (
 	}
 
 	networkType := annotation[ServiceAnnotationLoadBalancerNetworkType]
-	if config.VxNetID == nil && qc.Config.DefaultVxNetForLB != "" {
-		config.VxNetID = qcservice.String(qc.Config.DefaultVxNetForLB)
-	}
 	switch networkType {
 	case NetworkModePublic:
 		config.NetworkType = networkType
 	case NetworkModeInternal:
 		config.NetworkType = networkType
+		if config.VxNetID == nil && qc.Config.DefaultVxNetForLB != "" {
+			config.VxNetID = qcservice.String(qc.Config.DefaultVxNetForLB)
+		}
 	default:
 		config.NetworkType = NetworkModePublic
 	}
@@ -208,14 +209,14 @@ func (qc *QingCloud) ParseServiceLBConfig(cluster string, service *v1.Service) (
 	if lbType, ok := annotation[ServiceAnnotationLoadBalancerType]; ok {
 		t, err := strconv.Atoi(lbType)
 		if err != nil {
-			return nil, fmt.Errorf("Pls spec a valid value of loadBalancer type, acceptted values are '0-3',err: %s", err.Error())
+			return nil, fmt.Errorf("pls spec a valid value of loadBalancer type, acceptted values are '0-3',err: %s", err.Error())
 		}
 		config.LoadBalancerType = &t
 	}
 	if nodes, ok := annotation[ServiceAnnotationLoadBalancerNodes]; ok {
 		num, err := strconv.Atoi(nodes)
 		if err != nil {
-			return nil, fmt.Errorf("Pls spec a valid value of loadBalancer node number")
+			return nil, fmt.Errorf("pls spec a valid value of loadBalancer node number")
 		}
 		config.NodeCount = &num
 	}
@@ -235,7 +236,7 @@ func (qc *QingCloud) ParseServiceLBConfig(cluster string, service *v1.Service) (
 				break
 			} else {
 				if config.InternalIP == nil || config.InternalReuseID == nil {
-					return nil, fmt.Errorf("Must specify reuse-id or internalip if wants to use shared internal lb")
+					return nil, fmt.Errorf("must specify reuse-id or internalip if wants to use shared internal lb")
 				}
 
 				if config.InternalReuseID != nil {

--- a/pkg/qingcloud/qingcloud.go
+++ b/pkg/qingcloud/qingcloud.go
@@ -152,9 +152,9 @@ func (qc *QingCloud) GetLoadBalancerName(_ context.Context, _ string, service *v
 // GetLoadBalancer returns whether the specified load balancer exists, and
 // if so, what its status is.
 func (qc *QingCloud) GetLoadBalancer(ctx context.Context, _ string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
-	_, lb, err := qc.getLoadBalancer(service)
+	_, lb, err := qc.getLoadBalancerBeforeDelete(service)
 
-	if errors.IsResourceNotFound(err) {
+	if errors.IsResourceNotFound(err) || lb == nil {
 		return nil, false, nil
 	}
 
@@ -464,9 +464,9 @@ func (qc *QingCloud) createListenersAndBackends(conf *LoadBalancerConfig, status
 // Implementations must treat the *v1.Service parameter as read-only and not modify it.
 // Parameter 'clusterName' is the name of the cluster as presented to kube-controller-manager
 func (qc *QingCloud) EnsureLoadBalancerDeleted(ctx context.Context, _ string, service *v1.Service) error {
-	lbConfig, lb, err := qc.getLoadBalancer(service)
+	lbConfig, lb, err := qc.getLoadBalancerBeforeDelete(service)
 	klog.V(4).Infof("==== EnsureLoadBalancerDeleted %s config %s ====", spew.Sdump(lb), spew.Sdump(lbConfig))
-	if errors.IsResourceNotFound(err) {
+	if errors.IsResourceNotFound(err) || lb == nil {
 		return nil
 	}
 


### PR DESCRIPTION
do not add lb to vxnet when create public lb; unless add `service.beta.kubernetes.io/qingcloud-load-balancer-vxnet-id` to service annotation;

fix bug: ignore endpoint change if the endpoint do not has s service;

Signed-off-by: gangqiangwang <gangqiangwang@yunify.com>;